### PR TITLE
Rename `.flatten` to `.flat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ New methods are added to `%Map%`.
 
 * `Set.prototype.isSubsetOf(otherSet)`
 * `Set.prototype.isSupersetOf(iterable)`
-* `Set.prototype.flatMap`, `Set.prototype.flatten` - should be added if [`Array.prototype.flatMap`](https://github.com/tc39/proposal-flatMap) is added to language
+* `Set.prototype.flatMap`, `Set.prototype.flat` - should be added if [`Array.prototype.flatMap`](https://github.com/tc39/proposal-flatMap) is added to language
 
 # Why not `%IteratorPrototype%` methods
 


### PR DESCRIPTION
[`.flatten` renamed to `.flat`](https://github.com/tc39/proposal-flatMap/commit/093eacc7fe0906e70f7626bf6c7d6e9dfc53cce9), so rename it in the readme of this proposal too.