### PR TITLE
Add polyfill links

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,27 @@ New methods are added to `WeakMap.prototype`.
 
 ## Polyfill
 
-* [core-js/packages/core-js/features/set](https://github.com/zloirock/core-js/tree/master/packages/core-js/features/set)
-* [core-js/packages/core-js/features/map](https://github.com/zloirock/core-js/tree/master/packages/core-js/features/map)
-* [core-js/packages/core-js/features/weak-set](https://github.com/zloirock/core-js/tree/master/packages/core-js/features/weak-set)
-* [core-js/packages/core-js/features/weak-map](https://github.com/zloirock/core-js/tree/master/packages/core-js/features/weak-map)
+The polyfill is available in the [core-js](https://github.com/zloirock/core-js) library.
+You can find it in the [ECMAScript proposal section](https://github.com/zloirock/core-js#ecmascript-proposals) 
+/ **Stage 1 proposals** / **New Set and Map methods proposal**.
+
+For all new collection methods include this at the top of your entry point.
+```js
+require('core-js/proposals/collection-methods');
+
+const colors = new Map([['red', '#FF0000'], ['gold', '#FFD700']]);
+colors
+  .mapKeys((value, key) => key.toUpperCase()) // Map { 'RED' => '#FF0000', 'GOLD' => '#FFD700' }
+  .mapValues(value => value.toLowerCase()); // Map { 'RED' => '#ff0000', 'GOLD' => '#ffd700' }
+```
+For a specific method include the needed polyfill directly.
+```js
+require('core-js/features/set/join');
+
+const mySet = new Set(['Just', 'like', 'an', 'array']);
+mySet.join(' '); // Just like an array
+```
+
 
 ## Not included in this proposal but worth considering
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ New methods are added to `WeakMap.prototype`.
 * New methods:
   * `WeakMap.prototype.deleteAll(...elements)` - similar to `Map.prototype.deleteAll`.
 
+## Polyfill
+
+* [core-js/packages/core-js/features/set](https://github.com/zloirock/core-js/tree/master/packages/core-js/features/set)
+* [core-js/packages/core-js/features/map](https://github.com/zloirock/core-js/tree/master/packages/core-js/features/map)
+* [core-js/packages/core-js/features/weak-set](https://github.com/zloirock/core-js/tree/master/packages/core-js/features/weak-set)
+* [core-js/packages/core-js/features/weak-map](https://github.com/zloirock/core-js/tree/master/packages/core-js/features/weak-map)
+
 ## Not included in this proposal but worth considering
 
 * `Set.prototype.flatMap`, `Set.prototype.flat` - should be added if [`Array.prototype.flatMap`](https://github.com/tc39/proposal-flatMap) is added to language

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ New methods are added to `WeakMap.prototype`.
 
 ## Polyfill
 
-The polyfill is available in the [core-js](https://github.com/zloirock/core-js) library.
+A polyfill is available in the [core-js](https://github.com/zloirock/core-js) library.
 You can find it in the [ECMAScript proposal section](https://github.com/zloirock/core-js#ecmascript-proposals) 
 / **Stage 1 proposals** / **New Set and Map methods proposal**.
 


### PR DESCRIPTION
I have added the polyfill section with links to `core-js` library. I have also added some examples on how to use it.